### PR TITLE
fix: exclude @types/node from browser script tsconfig

### DIFF
--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -8,7 +8,8 @@
     "strict": true,
     "noEmit": false,
     "declaration": false,
-    "sourceMap": false
+    "sourceMap": false,
+    "types": []
   },
   "include": ["src/scripts/**/*.ts"]
 }


### PR DESCRIPTION
Browser scripts only need DOM types (already provided via lib). Auto-including @types/node causes TS2792 errors because modern @types/node imports undici-types using syntax that requires node16/bundler moduleResolution.